### PR TITLE
Allow using of windDir ordinals when using wind

### DIFF
--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -2392,7 +2392,7 @@ function showChart(json_file, prepend_renderTo = false) {
                     options.yAxis[this_yAxis].minorGridLineWidth = 1;
                 }
 
-                if (s.obsType == "windDir") {
+                if (s.obsType == "windDir" || s.obsType == "wind") {
                     options.yAxis[this_yAxis].tickInterval = 90;
                     options.yAxis[this_yAxis].labels = {
                         useHTML: true,


### PR DESCRIPTION
This change is to support issue #824

In Summary;
Support the use of wind rather than windDir as a directional vector when user wanting to graph using an aggregate_interval which is not the same as your archive period (eg 300 seconds when archive is 60 seconds)

User must be on weewx 4.9.1 if aggregate interval is less than one day.